### PR TITLE
Update SDK to 0.9.0.9

### DIFF
--- a/Runtime/Plugins/Android/AptoideBillingSDKUnityBridge.java
+++ b/Runtime/Plugins/Android/AptoideBillingSDKUnityBridge.java
@@ -107,6 +107,13 @@ public class AptoideBillingSDKUnityBridge {
         return billingClient.launchBillingFlow(UnityPlayer.currentActivity, flowParams);
     }
 
+    public static int launchBillingFlow(String sku, String skuType, String developerPayload,
+            String obfuscatedAccountId, boolean freeTrial) {
+        BillingFlowParams flowParams = new BillingFlowParams(sku, skuType, null, developerPayload,
+                "BDS", obfuscatedAccountId, freeTrial);
+        return billingClient.launchBillingFlow(UnityPlayer.currentActivity, flowParams);
+    }
+
     public static void consumeAsync(String purchaseToken) {
         billingClient.consumeAsync(purchaseToken, consumeResponseListener);
     }
@@ -161,6 +168,7 @@ public class AptoideBillingSDKUnityBridge {
                 purchaseJsonObject.put("purchaseTime", purchase.getPurchaseTime());
                 purchaseJsonObject.put("purchaseState", purchase.getPurchaseState());
                 purchaseJsonObject.put("developerPayload", purchase.getDeveloperPayload());
+                purchaseJsonObject.put("obfuscatedAccountId", purchase.getObfuscatedAccountId());
                 purchaseJsonObject.put("token", purchase.getToken());
                 purchaseJsonObject.put("originalJson", purchase.getOriginalJson());
                 purchaseJsonObject.put("signature", purchase.getSignature());
@@ -203,6 +211,15 @@ public class AptoideBillingSDKUnityBridge {
                 skuDetailsJsonObject.put("title", skuDetails.getTitle());
                 if (skuDetails.getDescription() != null) {
                     skuDetailsJsonObject.put("description", skuDetails.getDescription());
+                }
+                if (skuDetails.getPeriod() != null) {
+                    skuDetailsJsonObject.put("period", skuDetails.getPeriod());
+                }
+                if (skuDetails.getTrialPeriod() != null) {
+                    skuDetailsJsonObject.put("trialPeriod", skuDetails.getTrialPeriod());
+                }
+                if (skuDetails.getTrialPeriodEndDate() != null) {
+                    skuDetailsJsonObject.put("trialPeriodEndDate", skuDetails.getTrialPeriodEndDate());
                 }
                 skuDetailsjsonArray.put(skuDetailsJsonObject);
             }

--- a/Runtime/Plugins/Android/mainTemplate.gradle
+++ b/Runtime/Plugins/Android/mainTemplate.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation("io.catappult:android-appcoins-billing:0.9.0.8")
+    implementation("io.catappult:android-appcoins-billing:0.9.0.9")
     implementation("org.json:json:20210307")
 **DEPS**}
 

--- a/Runtime/SDK/AptoideBillingSDKManager.cs
+++ b/Runtime/SDK/AptoideBillingSDKManager.cs
@@ -77,6 +77,14 @@ public class AptoideBillingSDKManager : MonoBehaviour
         return launchBillingFlowResponseCode;
     }
 
+    public static int LaunchBillingFlow(string sku, string skuType, string developerPayload, string obfuscatedAccountId, bool freeTrial)
+    {
+        int launchBillingFlowResponseCode = aptoideBillingSDKUnityBridge?.CallStatic<int>("launchBillingFlow", sku, skuType, developerPayload, obfuscatedAccountId, freeTrial) ?? -1;
+        Debug.Log($"AptoideBillingSDKManager | LaunchBillingFlow: {launchBillingFlowResponseCode}");
+
+        return launchBillingFlowResponseCode;
+    }
+
     public static void ConsumeAsync(string purchaseToken)
     {
         aptoideBillingSDKUnityBridge?.CallStatic("consumeAsync", purchaseToken);

--- a/Runtime/SDK/Purchase.cs
+++ b/Runtime/SDK/Purchase.cs
@@ -3,6 +3,7 @@ public class Purchase
 {
     // Purchase details
     public string developerPayload;
+    public string obfuscatedAccountId;
     public bool isAutoRenewing;
     public string itemType;
     public string orderId;

--- a/Runtime/SDK/SkuDetails.cs
+++ b/Runtime/SDK/SkuDetails.cs
@@ -16,4 +16,7 @@ public class SkuDetails
     public string fiatPriceCurrencyCode;
     public string title;
     public string description;
+    public string period;
+    public string trialPeriod;
+    public string trialPeriodEndDate;
 }


### PR DESCRIPTION
**What does this PR do?**

This PR updates the version of the Native SDK to 0.9.0.9 and applies to logic to support the new features added in that version.

The method `launchBillingFlow` contains now a version with 2 other parameters `String obfuscatedAccountId` and `Boolean freeTrial`.

**What are the relevant tickets?**

Tickets related to this pull-request:
- [APT-4802](https://aptoide.atlassian.net/browse/APT-4802)

**Questions:**

Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass